### PR TITLE
treewide: use $(CC) instead of hardcoding gcc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 CFILES := $(shell ls src/*.c)
 
 eigenmath: eigenmath.c
-	gcc -Wall -O0 -o eigenmath eigenmath.c -lm
+	$(CC) -Wall -O0 -o eigenmath eigenmath.c -lm
 
 eigenmath.c: src/defs.h src/prototypes.h $(CFILES)
 	cat src/defs.h src/prototypes.h $(CFILES) > eigenmath.c

--- a/src/Makefile
+++ b/src/Makefile
@@ -3,7 +3,7 @@
 CFILES := $(shell ls *.c)
 
 eigenmath: defs.h prototypes.h $(CFILES)
-	gcc -Wall -O0 -o eigenmath -include defs.h -include prototypes.h $(CFILES) -lm
+	$(CC) -Wall -O0 -o eigenmath -include defs.h -include prototypes.h $(CFILES) -lm
 
 prototypes.h: $(CFILES)
 	make -s -C ../tools make-prototypes

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -5,10 +5,10 @@ default:
 	make make-prototypes
 
 wcheck: wcheck.c
-	gcc -Wall -O0 -o wcheck wcheck.c
+	$(CC) -Wall -O0 -o wcheck wcheck.c
 
 make-prototypes: make-prototypes.c
-	gcc -Wall -O0 -o make-prototypes make-prototypes.c
+	$(CC) -Wall -O0 -o make-prototypes make-prototypes.c
 
 clean:
 	rm -f wcheck make-prototypes


### PR DESCRIPTION
Reference: https://www.gnu.org/software/make/manual/html_node/Implicit-Variables.html